### PR TITLE
give hint to GitHub's linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,2 @@
-*.yml linguist-vendored=false
-docs/* linguist-vendored=false
-tools/*.yml linguist-vendored=false
-tools/* linguist-vendored=false
+docs/* linguist-vendored
+tools/* linguist-vendored


### PR DESCRIPTION
GitHub is detecting repo as Ruby project because of the files in docs and toos directories. These are only supporting tools. 

With this change we give hint to GitHub's linguist app to not conisder those directories
while analyzing this repo.