### PR TITLE
Fix incorrect unit type in examples

### DIFF
--- a/capabilities/diagnostics.yml
+++ b/capabilities/diagnostics.yml
@@ -64,7 +64,7 @@ properties:
     size: 10
     description: Engine RPM (revolutions per minute)
     examples:
-      - data_component: '030240a3880000000000'
+      - data_component: '030040a3880000000000'
         value:
           revolutions_per_minute: 2500.0
         description: Engine RPM is 2500.0
@@ -191,7 +191,7 @@ properties:
     size: 10
     description: The accumulated time of engine operation
     examples:
-      - data_component: '0700409772999999999a'
+      - data_component: '0702409772999999999a'
         value:
           hours: 1500.65
         description: The engine has operated 1'500.65h in total
@@ -429,7 +429,7 @@ properties:
     size: 10
     description: The accumulated time of engine operation
     examples:
-      - data_component: '0700409772999999999a'
+      - data_component: '0702409772999999999a'
         value:
           hours: 1500.65
         description: The engine has operated 1'500.65h in total

--- a/capabilities/honk_horn_flash_lights.yml
+++ b/capabilities/honk_horn_flash_lights.yml
@@ -88,7 +88,7 @@ properties:
     size: 10
     description: Time to honk the horn
     examples:
-      - data_component: '07024000000000000000'
+      - data_component: '07004000000000000000'
         value:
           seconds: 2.0
         description: Honk the horn for 2.0s

--- a/capabilities/navi_destination.yml
+++ b/capabilities/navi_destination.yml
@@ -75,7 +75,7 @@ properties:
     size: 10
     description: Remaining time until reaching the destination.
     examples:
-      - data_component: '07004004cccccccccccd'
+      - data_component: '07024004cccccccccccd'
         value:
           hours: 2.6
         description: Remaining time to destination is 2.6h


### PR DESCRIPTION
Some examples in the spec were not showing the correct unit based on the data_component value. This PR updates the data_component values so they match up.