### PR TITLE
Update incorrect property name in historical example

### DIFF
--- a/capabilities/historical.yml
+++ b/capabilities/historical.yml
@@ -40,7 +40,7 @@ properties:
       - data_component: '0c0020010600040100010004000501000200010400050100020201a2000b0100800000173426608d0'
         values:
           doors:
-            lock_state: 'unlocked'
+            locks_state: 'unlocked'
             positions:
               - location: 'front_left'
                 position: 'open'


### PR DESCRIPTION
According to doors.yml, the property at 0x06 is called locks_state, not lock_state: https://github.com/highmobility/auto-api/blob/level12/capabilities/doors.yml#L128