### PR TITLE
Define on and off values as strings

### DIFF
--- a/misc/custom_types.yml
+++ b/misc/custom_types.yml
@@ -252,9 +252,9 @@ types:
     controls: 'switch'
     enum_values:
       - id: 0x00
-        name: off
+        name: 'off'
       - id: 0x01
-        name: on
+        name: 'on'
     # MARK: Percentage
   - name: percentage
     name_cased: percentage


### PR DESCRIPTION
It appears that the YAML-to-JSON conversion script still uses the old
yaml specification where "on" and "off" values are treated as boolean
values rather than a string.

This PR explicitly wraps these values in quotes so they are treated as
strings as they should. I've recently seen this being done _somewhere
else_ (citation needed) so it should be OK.

Please review that this doesn't break our implementations where we parse
the yaml directly before merging this PR.