### PR TITLE
use more general oem_error type

### DIFF
--- a/capabilities/failure_message.yml
+++ b/capabilities/failure_message.yml
@@ -77,9 +77,9 @@ properties:
         name_pretty: Rate Limit
         description: Capability rate limit has been exceeded
       - id: 0x08
-        name: internal_oem_error
-        name_pretty: Internal OEM error
-        description: API call to OEM returned an error
+        name: oem_error
+        name_pretty: OEM error
+        description: API call to an OEM returned an error
     examples:
       - data_component: '01'
         value: 'unauthorised'

--- a/misc/custom_types.yml
+++ b/misc/custom_types.yml
@@ -1129,7 +1129,7 @@ types:
           - id: 0x05
             name: pending
           - id: 0x06
-            name: internal_oem_error
+            name: oem_error
       - name: description
         name_cased: description
         name_pretty: Description


### PR DESCRIPTION
It allows us to use this error type when something
anything is wrong with an OEM.