### PR TITLE
Update Volvo brand name

### DIFF
--- a/misc/universal_properties.yml
+++ b/misc/universal_properties.yml
@@ -150,7 +150,8 @@ universal_properties:
       - id: 0x28
         name: volkswagen
       - id: 0x29
-        name: volvo
+        name: volvo_cars
+        name_pretty: Volvo Cars
       - id: 0x2a
         name: emulator
     examples:


### PR DESCRIPTION
The correct name is `Volvo Cars` as there are other Volvo brands like Volvo Trucks.

I'm not sure if we can include it in L12 though. I'll leave this to you to decide but ofc good to be fixed sooner