### PR TITLE
Add new properties for `13.4`

### DIFF
--- a/capabilities/charging.yml
+++ b/capabilities/charging.yml
@@ -381,6 +381,9 @@ properties:
       - id: 0x0c
         name: flap_open
         disabled_in_setter: true
+      - id: 0x0d
+        name: ready_for_charging
+        disabled_in_setter: true
     examples:
       - data_component: '01'
         value: 'charging'
@@ -598,7 +601,7 @@ properties:
     examples:
       - data_component: '1402405e000000000000'
         value:
-           kilowatts: 120.0
+          kilowatts: 120.0
         description: Auxiliary power is 120.0kW.
   - id: 0x26
     name: charging_complete_lock
@@ -1054,6 +1057,8 @@ properties:
         name: initialising
       - id: 0x0b
         name: error
+      - id: 0x0c
+        name: blue
     examples:
       - data_component: '00'
         value: 'no_colour'
@@ -1180,6 +1185,8 @@ properties:
         name: digital_communication_ended
       - id: 0x04
         name: station_ready
+      - id: 0x05
+        name: active
     examples:
       - data_component: '04'
         value: 'station_ready'
@@ -1306,3 +1313,81 @@ properties:
         value:
           kilowatts: 120.0
         description: Charger power is 120.0kW.
+
+  - id: 0x4d
+    name: conserving_charge
+    name_cased: conservingCharge
+    name_pretty: Conserving charge
+    added: 0x0d
+    type: types.active_state
+    description: Indicates if the vehicle is conserving charge.
+    examples:
+      - data_component: '01'
+        value: 'active'
+        description: Vehicle is conserving charge.
+
+  - id: 0x4e
+    name: charging_rate_distance
+    name_cased: chargingRateDistance
+    name_pretty: Charging rate distance
+    added: 0x0d
+    type: types.distance_over_time
+    description: Range increase per time unit during ongoing charging process based on the average energy comsumption for driving.
+    examples:
+      - data_component: '12044062c0000000000007023ff0000000000000'
+        values:
+          distance:
+            kilometers: 150.0
+          time:
+            hours: 1.0
+        description: Range increases by 150.0km in 1.0h.
+
+  - id: 0x4f
+    name: charging_scenario
+    name_cased: chargingScenario
+    name_pretty: Charging scenario
+    added: 0x0d
+    type: enum
+    size: 1
+    description: Charging scenario.
+    enum_values:
+      - id: 0x00
+        name: 'off'
+      - id: 0x01
+        name: charging_to_departure_time_finished
+      - id: 0x02
+        name: immediately_charging_finished
+      - id: 0x03
+        name: optimised_charging_finished
+      - id: 0x04
+        name: charging_to_departure_time_active
+      - id: 0x05
+        name: immediately_charging_active
+      - id: 0x06
+        name: optimised_charging_active
+      - id: 0x07
+        name: charging_to_departure_time_waiting
+      - id: 0x08
+        name: optimised_charging_waiting
+      - id: 0x09
+        name: no_grid_voltage
+      - id: 0x0a
+        name: error_lock
+      - id: 0x0b
+        name: error_charging_system
+      - id: 0x0c
+        name: initialization_charging_communication
+      - id: 0x0d
+        name: immediately_optimised_charging_active
+      - id: 0x0e
+        name: immediately_optimised_charging_finished
+      - id: 0x0f
+        name: emergency_charging
+      - id: 0x10
+        name: charging_interrupt_by_user
+      - id: 0x11
+        name: plug_releasable
+    examples:
+      - data_component: '01'
+        value: 'charging_to_departure_time_finished'
+        description: Charging scenario is 'charging_to_departure_time_finished'.

--- a/capabilities/dashboard_lights.yml
+++ b/capabilities/dashboard_lights.yml
@@ -1075,3 +1075,26 @@ properties:
       - data_component: '05'
         value: 'high_beam'
         description: A high beam has failed.
+
+  - id: 0x03
+    name: dynamic_warnings
+    name_cased: dynamicWarnings
+    name_pretty: Dynamic warnings
+    name_singular: dynamic_warning
+    added: 0x0d
+    type: types.dynamic_warning
+    multiple: true
+    description: Dynamic warnings
+    examples:
+      - data_component: '0006656e67696e650006616263303132000e456e67696e65207761726e696e67'
+        values:
+          category: 'engine'
+          id: 'abc012'
+          description: 'Engine warning'
+        description: Dynamic warning with category 'engine' and id 'abc012' has a description 'Engine warning'.
+      - data_component: '000a686561646c69676874730007666f6f5f3132330012486561646c6967687473207761726e696e67'
+        values:
+          category: 'headlights'
+          id: 'foo_123'
+          description: 'Headlights warning'
+        description: Dynamic warning with category 'headlights' and id 'foo_123' has a description 'Headlights warning'.

--- a/capabilities/diagnostics.yml
+++ b/capabilities/diagnostics.yml
@@ -958,7 +958,7 @@ properties:
         value: 'active'
         description: Passenger airbag is `active`
 
-  - id: 0x2d
+  - id: 0x39
     name: estimated_primary_powertrain_range
     name_cased: estimatedPrimaryPowertrainRange
     name_pretty: Estimated primary powertrain range

--- a/capabilities/diagnostics.yml
+++ b/capabilities/diagnostics.yml
@@ -730,7 +730,7 @@ properties:
     examples:
       - data_component: '00'
         value: 'measured'
-        description:  Fuel level has been measured
+        description: Fuel level has been measured
   - id: 0x2f
     name: tire_pressures_targets
     name_cased: tirePressuresTargets
@@ -957,3 +957,17 @@ properties:
       - data_component: '01'
         value: 'active'
         description: Passenger airbag is `active`
+
+  - id: 0x2d
+    name: estimated_primary_powertrain_range
+    name_cased: estimatedPrimaryPowertrainRange
+    name_pretty: Estimated primary powertrain range
+    added: 0x0d
+    type: unit.length
+    size: 10
+    description: Estimated primary powertrain range
+    examples:
+      - data_component: '12044070900000000000'
+        value:
+          kilometers: 265.0
+        description: Estimated primary powertrain`s range is 256.0km

--- a/capabilities/navi_destination.yml
+++ b/capabilities/navi_destination.yml
@@ -91,3 +91,26 @@ properties:
         value:
           kilometers: 1337.0
         description: Remaining distance to destination is 1337.0km
+
+  - id: 0x07
+    name: battery_consumption_to_destination
+    name_cased: batteryConsumptionToDestination
+    name_pretty: Battery consumption to destination
+    type: types.percentage
+    description: Required battery charge level to proceed to the next destination.
+    examples:
+      - data_component: '3fcd70a3d70a3d71'
+        value: 0.23
+        description: Required battery charge level to proceed to the next destination is 23%.
+
+  - id: 0x08
+    name: charging_time_for_destination
+    name_cased: chargingTimeForDestination
+    name_pretty: Charging time for destination
+    type: unit.duration
+    description: Required charging time to reach the next destination.
+    examples:
+      - data_component: '0701404b800000000000'
+        value:
+          minutes: 55.0
+        description: Required charging time to reach the next destination is 55.0min.

--- a/capabilities/trips.yml
+++ b/capabilities/trips.yml
@@ -423,3 +423,29 @@ properties:
       - data_component: '00a1'
         value: 161
         description: Brakes were applied 161 times during the trip.
+
+  - id: 0x18
+    name: id
+    name_cased: id
+    name_pretty: ID
+    added: 0x0d
+    type: string
+    description: ID of the trip
+    examples:
+      - data_component: '313233616263'
+        value: '123abc'
+        description: ID of the trip is '123abc'.
+
+  - id: 0x19
+    name: duration
+    name_cased: duration
+    name_pretty: Duration
+    added: 0x0d
+    type: unit.duration
+    size: 10
+    description: Duration of the trip
+    examples:
+      - data_component: '0701405ec00000000000'
+        value:
+          hours: 123.0
+        description: Duration of trip was 123.0 minutes.

--- a/changelogs/L13.4_changelog.md
+++ b/changelogs/L13.4_changelog.md
@@ -7,6 +7,7 @@ Changes from L13.3 are divided into these sub-sections:
 
 * [Enums](#enums)
 * [Properties](#properties)
+* [Custom Types](#custom-types)
 
 
 ## Enums
@@ -27,6 +28,9 @@ New properties added to pre-existing capabilities:
   - `charging_rate_distance`
   - `charging_scenario`
 
+- *dashboard_lights*
+  - `dynamic_warnings`
+
 - _diagnostics_
   - `estimated_primary_powertrain_range`
 
@@ -37,3 +41,10 @@ New properties added to pre-existing capabilities:
 - _trips_
   - `id`
   - `duration`
+
+
+## Custom Types
+
+New custom types added.
+
+- `dynamic_warning`

--- a/changelogs/L13.4_changelog.md
+++ b/changelogs/L13.4_changelog.md
@@ -1,0 +1,39 @@
+# AutoAPI L13 Extensions #4 Changelog
+
+**Level 13** _4th extension_ (aka **L13.4**) contains only additive updates to the protocol.
+These include new properties for existing capabilities and additions to already existing enums.
+
+Changes from L13.3 are divided into these sub-sections:
+
+* [Enums](#enums)
+* [Properties](#properties)
+
+
+## Enums
+
+Some enums have gained new values.
+
+- `charging.status` (added `ready_for_charging`)
+- `charging.battery_led` (added `blue`)
+- `charging.station_status` (added `active`)
+
+
+## Properties
+
+New properties added to pre-existing capabilities:
+
+- _charging_
+  - `conserving_charge`
+  - `charging_rate_distance`
+  - `charging_scenario`
+
+- _diagnostics_
+  - `estimated_primary_powertrain_range`
+
+- *navi_destination*
+  - `battery_consumption_to_destination`
+  - `charging_time_for_destination`
+
+- _trips_
+  - `id`
+  - `duration`

--- a/misc/custom_types.yml
+++ b/misc/custom_types.yml
@@ -6,7 +6,6 @@
 # Additionally defines commonly used 'enum' types.
 #
 
-
 types:
   # MARK: Active State
   - name: active_state
@@ -1666,6 +1665,27 @@ types:
         type: unit.energy
         size: 10
         description: Energy consumption in the driving mode
+    # MARK: Dynamic Warning
+  - name: dynamic_warning
+    name_cased: dynamicWarning
+    name_pretty: Dynamic warning
+    type: custom
+    items:
+      - name: category
+        name_cased: category
+        name_pretty: Category
+        type: string
+        description: Category of the warning
+      - name: id
+        name_cased: id
+        name_pretty: ID
+        type: string
+        description: Identifier of the warning
+      - name: description
+        name_cased: description
+        name_pretty: Description
+        type: string
+        description: Description of the warning
     # MARK: EcoDriving Threshold
   - name: eco_driving_threshold
     name_cased: ecoDrivingThreshold


### PR DESCRIPTION
Copy of the changelog:

# AutoAPI L13 Extensions 4 Changelog

**Level 13** _4th extension_ (aka **L13.4**) contains only additive updates to the protocol.
These include new properties for existing capabilities and additions to already existing enums.

Changes from L13.3 are divided into these sub-sections:

* [Enums](#enums)
* [Properties](#properties)


## Enums

Some enums have gained new values.

- `charging.status` (added `ready_for_charging`)
- `charging.battery_led` (added `blue`)
- `charging.station_status` (added `active`)


## Properties

New properties added to pre-existing capabilities:

- _charging_
  - `conserving_charge`
  - `charging_rate_distance`
  - `charging_scenario`

- _diagnostics_
  - `estimated_primary_powertrain_range`

- *navi_destination*
  - `battery_consumption_to_destination`
  - `charging_time_for_destination`

- _trips_
  - `id`
  - `duration`